### PR TITLE
Respect JUnit 5 `junit.platform.stacktrace.pruning.enabled` flag for stack trace pruning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,3 @@
+# 0.5.1
+
+* [Respect JUnit 5 `junit.platform.stacktrace.pruning.enabled` flag for stack trace pruning](https://github.com/laech/java-stacksrc/pull/4)

--- a/core/src/main/java/nz/lae/stacksrc/DecoratedAssertionError.java
+++ b/core/src/main/java/nz/lae/stacksrc/DecoratedAssertionError.java
@@ -14,9 +14,18 @@ public final class DecoratedAssertionError extends AssertionError {
   private final String decoratedStackTrace;
 
   public DecoratedAssertionError(Throwable original) {
+    this(original, null);
+  }
+
+  /**
+   * @param pruneStackTraceKeepFromClass if not null, will prune the stack traces, keeping only
+   *     elements that are called directly or indirectly by this class
+   */
+  public DecoratedAssertionError(Throwable original, Class<?> pruneStackTraceKeepFromClass) {
     super(original.getMessage());
     this.original = original;
-    this.decoratedStackTrace = StackTraceDecorator.get().decorate(original);
+    this.decoratedStackTrace =
+        StackTraceDecorator.get().decorate(original, pruneStackTraceKeepFromClass);
     setStackTrace(new StackTraceElement[0]);
   }
 

--- a/core/src/test/java/nz/lae/stacksrc/CauseTest.java
+++ b/core/src/test/java/nz/lae/stacksrc/CauseTest.java
@@ -1,6 +1,5 @@
 package nz.lae.stacksrc;
 
-import static java.util.stream.Collectors.joining;
 import static nz.lae.stacksrc.test.Assertions.assertStackTrace;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -22,50 +21,39 @@ class CauseTest {
     var expected =
         """
 java.lang.AssertionError: rethrown
-	at nz.lae.stacksrc.CauseTest.doThrow(CauseTest.java:15)
+	at nz.lae.stacksrc.CauseTest.doThrow(CauseTest.java:14)
 
-	   13        throw new IllegalArgumentException("test");
-	   14      } catch (IllegalArgumentException e) {
-	-> 15        throw new AssertionError("rethrown", e);
-	   16      }
-	   17    }
+	   12        throw new IllegalArgumentException("test");
+	   13      } catch (IllegalArgumentException e) {
+	-> 14        throw new AssertionError("rethrown", e);
+	   15      }
+	   16    }
 
 
 	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:53)
 	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:35)
 	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3111)
-	at nz.lae.stacksrc.CauseTest.run(CauseTest.java:21)
+	at nz.lae.stacksrc.CauseTest.run(CauseTest.java:20)
 
-	   19    @Test
-	   20    void run() {
-	-> 21      var exception = assertThrows(AssertionError.class, this::doThrow);
-	   22      var expected =
-	   23          ""\"
+	   18    @Test
+	   19    void run() {
+	-> 20      var exception = assertThrows(AssertionError.class, this::doThrow);
+	   21      var expected =
+	   22          ""\"
 
 
 Caused by: java.lang.IllegalArgumentException: test
-	at nz.lae.stacksrc.CauseTest.doThrow(CauseTest.java:13)
+	at nz.lae.stacksrc.CauseTest.doThrow(CauseTest.java:12)
 
-	   11    private void doThrow() {
-	   12      try {
-	-> 13        throw new IllegalArgumentException("test");
-	   14      } catch (IllegalArgumentException e) {
-	   15        throw new AssertionError("rethrown", e);
+	   10    private void doThrow() {
+	   11      try {
+	-> 12        throw new IllegalArgumentException("test");
+	   13      } catch (IllegalArgumentException e) {
+	   14        throw new AssertionError("rethrown", e);
 
-    """;
 
-    var actual =
-        StackTraceDecorator.get()
-            .decorate(exception)
-            .lines()
-            .filter(line -> !line.contains("java.base/"))
-            .filter(line -> !line.contains("jdk.proxy1/"))
-            .filter(line -> !line.contains("org.junit.platform"))
-            .filter(line -> !line.contains("org.junit.jupiter.engine"))
-            .filter(line -> !line.contains("org.gradle"))
-            .filter(line -> !line.contains("\t..."))
-            .collect(joining("\n"));
+	... 4 more""";
 
-    assertStackTrace(expected, actual);
+    assertStackTrace(expected, StackTraceDecorator.get().decorate(exception, getClass()));
   }
 }

--- a/core/src/test/java/nz/lae/stacksrc/SupressTest.java
+++ b/core/src/test/java/nz/lae/stacksrc/SupressTest.java
@@ -1,6 +1,5 @@
 package nz.lae.stacksrc;
 
-import static java.util.stream.Collectors.joining;
 import static nz.lae.stacksrc.test.Assertions.assertStackTrace;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -29,59 +28,49 @@ class SupressTest {
     var expected =
         """
 java.lang.AssertionError: rethrown
-	at nz.lae.stacksrc.SupressTest.doThrow(SupressTest.java:12)
+	at nz.lae.stacksrc.SupressTest.doThrow(SupressTest.java:11)
 
-	   11    private void doThrow() {
-	-> 12      var root = new AssertionError("rethrown");
-	   13      try {
-	   14        throw new IllegalArgumentException("test1");
+	   10    private void doThrow() {
+	-> 11      var root = new AssertionError("rethrown");
+	   12      try {
+	   13        throw new IllegalArgumentException("test1");
 
 
 	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:53)
 	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:35)
 	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3111)
-	at nz.lae.stacksrc.SupressTest.run(SupressTest.java:28)
+	at nz.lae.stacksrc.SupressTest.run(SupressTest.java:27)
 
-	   26    @Test
-	   27    void run() {
-	-> 28      var exception = assertThrows(AssertionError.class, this::doThrow);
-	   29      var expected =
-	   30          ""\"
+	   25    @Test
+	   26    void run() {
+	-> 27      var exception = assertThrows(AssertionError.class, this::doThrow);
+	   28      var expected =
+	   29          ""\"
 
 
 	Suppressed: java.lang.IllegalArgumentException: test1
-		at nz.lae.stacksrc.SupressTest.doThrow(SupressTest.java:14)
+		at nz.lae.stacksrc.SupressTest.doThrow(SupressTest.java:13)
 
-		   12      var root = new AssertionError("rethrown");
-		   13      try {
-		-> 14        throw new IllegalArgumentException("test1");
-		   15      } catch (IllegalArgumentException e) {
-		   16        root.addSuppressed(e);
+		   11      var root = new AssertionError("rethrown");
+		   12      try {
+		-> 13        throw new IllegalArgumentException("test1");
+		   14      } catch (IllegalArgumentException e) {
+		   15        root.addSuppressed(e);
 
 
+		... 4 more
 	Suppressed: java.lang.IllegalArgumentException: test2
-		at nz.lae.stacksrc.SupressTest.doThrow(SupressTest.java:19)
+		at nz.lae.stacksrc.SupressTest.doThrow(SupressTest.java:18)
 
-		   17      }
-		   18      try {
-		-> 19        throw new IllegalArgumentException("test2");
-		   20      } catch (IllegalArgumentException e) {
-		   21        root.addSuppressed(e);
+		   16      }
+		   17      try {
+		-> 18        throw new IllegalArgumentException("test2");
+		   19      } catch (IllegalArgumentException e) {
+		   20        root.addSuppressed(e);
 
-    """;
 
-    var actual =
-        StackTraceDecorator.get()
-            .decorate(exception)
-            .lines()
-            .filter(line -> !line.contains("java.base/"))
-            .filter(line -> !line.contains("jdk.proxy1/"))
-            .filter(line -> !line.contains("org.junit.platform"))
-            .filter(line -> !line.contains("org.junit.jupiter.engine"))
-            .filter(line -> !line.contains("org.gradle"))
-            .filter(line -> !line.contains("\t..."))
-            .collect(joining("\n"));
+		... 4 more""";
 
-    assertStackTrace(expected, actual);
+    assertStackTrace(expected, StackTraceDecorator.get().decorate(exception, getClass()));
   }
 }

--- a/junit5/src/main/java/nz/lae/stacksrc/junit5/ErrorDecorator.java
+++ b/junit5/src/main/java/nz/lae/stacksrc/junit5/ErrorDecorator.java
@@ -57,6 +57,15 @@ public final class ErrorDecorator implements TestExecutionExceptionHandler {
     if (e instanceof IncompleteExecutionException || e instanceof DecoratedAssertionError) {
       throw e;
     }
-    throw new DecoratedAssertionError(e);
+
+    // https://junit.org/junit5/docs/current/user-guide/#stacktrace-pruning
+    var pruneStackTrace =
+        context
+            .getConfigurationParameter("junit.platform.stacktrace.pruning.enabled")
+            .map(Boolean::parseBoolean)
+            .orElse(true);
+
+    throw new DecoratedAssertionError(
+        e, pruneStackTrace ? context.getTestClass().orElse(null) : null);
   }
 }

--- a/junit5/src/test/java/nz/lae/stacksrc/junit5/ErrorDecoratorNestedTest.java
+++ b/junit5/src/test/java/nz/lae/stacksrc/junit5/ErrorDecoratorNestedTest.java
@@ -1,0 +1,49 @@
+package nz.lae.stacksrc.junit5;
+
+import static nz.lae.stacksrc.test.Assertions.assertStackTrace;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import nz.lae.stacksrc.DecoratedAssertionError;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+
+@ExtendWith({ErrorDecoratorNestedTest.AssertDecoration.class, ErrorDecorator.class})
+class ErrorDecoratorNestedTest {
+
+  @Nested
+  class NestedCheck {
+    @Test
+    void decoratesFailure() {
+      fail("testing failure");
+    }
+  }
+
+  static class AssertDecoration implements TestExecutionExceptionHandler {
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable e) {
+      var expected =
+          """
+nz.lae.stacksrc.DecoratedAssertionError:
+org.opentest4j.AssertionFailedError: testing failure
+	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38)
+	at org.junit.jupiter.api.Assertions.fail(Assertions.java:134)
+	at nz.lae.stacksrc.junit5.ErrorDecoratorNestedTest$NestedCheck.decoratesFailure(ErrorDecoratorNestedTest.java:21)
+
+	   19      @Test
+	   20      void decoratesFailure() {
+	-> 21        fail("testing failure");
+	   22      }
+	   23    }
+
+
+""";
+      assertEquals(DecoratedAssertionError.class, e.getClass());
+      assertStackTrace(expected, (DecoratedAssertionError) e);
+    }
+  }
+}


### PR DESCRIPTION
JUnit 5 has a flag `junit.platform.stacktrace.pruning.enabled` for stack trace prune, when enabled (by default) it will prune the stack trace of exceptions.

This change adds support for that, if enabled, we'll prune the stack trace in a similar way.

Fixes #3