### PR TITLE
Remove the prefix `nz.lae.stacksrc.DecoratedAssertionError:` from output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
 # 0.5.1
 
 * [Respect JUnit 5 `junit.platform.stacktrace.pruning.enabled` flag for stack trace pruning](https://github.com/laech/java-stacksrc/pull/4)
+* [Remove the prefix `nz.lae.stacksrc.DecoratedAssertionError:` from output](https://github.com/laech/java-stacksrc/pull/5)

--- a/core/src/main/java/nz/lae/stacksrc/DecoratedAssertionError.java
+++ b/core/src/main/java/nz/lae/stacksrc/DecoratedAssertionError.java
@@ -46,6 +46,6 @@ public final class DecoratedAssertionError extends AssertionError {
 
   @Override
   public String toString() {
-    return String.format("%s:%n%s", getClass().getName(), decoratedStackTrace);
+    return decoratedStackTrace;
   }
 }

--- a/core/src/test/java/NoPackageTest.java
+++ b/core/src/test/java/NoPackageTest.java
@@ -12,7 +12,6 @@ class NoPackageTest {
     } catch (AssertionError e) {
       var expected =
           """
-nz.lae.stacksrc.DecoratedAssertionError:
 java.lang.AssertionError: no package
 	at NoPackageTest.noPackage(NoPackageTest.java:11)
 

--- a/junit4/src/test/java/nz/lae/stacksrc/junit4/ErrorDecoratorTest.java
+++ b/junit4/src/test/java/nz/lae/stacksrc/junit4/ErrorDecoratorTest.java
@@ -36,7 +36,6 @@ public final class ErrorDecoratorTest {
   private static void assertFailure(DecoratedAssertionError e) {
     var expected =
         """
-nz.lae.stacksrc.DecoratedAssertionError:
 java.lang.AssertionError: testing failure
 	at org.junit.Assert.fail(Assert.java:89)
 	at nz.lae.stacksrc.junit4.ErrorDecoratorTest.decoratesFailure(ErrorDecoratorTest.java:16)

--- a/junit4/src/testIntegration/java/nz/lae/stacksrc/test/integration/GradleJUnit4IT.java
+++ b/junit4/src/testIntegration/java/nz/lae/stacksrc/test/integration/GradleJUnit4IT.java
@@ -22,7 +22,6 @@ class GradleJUnit4IT {
 
     var expectedStackTrace =
         """
-nz.lae.stacksrc.DecoratedAssertionError:
 java.lang.AssertionError: example failure
 	at org.junit.Assert.fail(Assert.java:89)
 	at nz.lae.stacksrc.test.integration.GradleJUnit4Test.run(GradleJUnit4Test.java:16)

--- a/junit4/src/testIntegration/java/nz/lae/stacksrc/test/integration/MavenJUnit4IT.java
+++ b/junit4/src/testIntegration/java/nz/lae/stacksrc/test/integration/MavenJUnit4IT.java
@@ -22,7 +22,6 @@ class MavenJUnit4IT {
 
     var expectedStackTrace =
         """
-nz.lae.stacksrc.DecoratedAssertionError:
 java.lang.AssertionError: example failure
 	at org.junit.Assert.fail(Assert.java:89)
 	at nz.lae.stacksrc.test.integration.MavenJUnit4Test.run(MavenJUnit4Test.java:16)

--- a/junit5/src/test/java/nz/lae/stacksrc/junit5/ErrorDecoratorNestedTest.java
+++ b/junit5/src/test/java/nz/lae/stacksrc/junit5/ErrorDecoratorNestedTest.java
@@ -28,7 +28,6 @@ class ErrorDecoratorNestedTest {
     public void handleTestExecutionException(ExtensionContext context, Throwable e) {
       var expected =
           """
-nz.lae.stacksrc.DecoratedAssertionError:
 org.opentest4j.AssertionFailedError: testing failure
 	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38)
 	at org.junit.jupiter.api.Assertions.fail(Assertions.java:134)

--- a/junit5/src/test/java/nz/lae/stacksrc/junit5/ErrorDecoratorTest.java
+++ b/junit5/src/test/java/nz/lae/stacksrc/junit5/ErrorDecoratorTest.java
@@ -24,7 +24,6 @@ class ErrorDecoratorTest {
     public void handleTestExecutionException(ExtensionContext context, Throwable e) {
       var expected =
           """
-nz.lae.stacksrc.DecoratedAssertionError:
 org.opentest4j.AssertionFailedError: testing failure
 	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38)
 	at org.junit.jupiter.api.Assertions.fail(Assertions.java:134)

--- a/junit5/src/testIntegration/java/nz/lae/stacksrc/test/integration/GradleJUnit5IT.java
+++ b/junit5/src/testIntegration/java/nz/lae/stacksrc/test/integration/GradleJUnit5IT.java
@@ -23,7 +23,6 @@ class GradleJUnit5IT {
 
     var expectedStackTrace =
         """
-nz.lae.stacksrc.DecoratedAssertionError:
 org.opentest4j.AssertionFailedError: example failure
 	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38)
 	at org.junit.jupiter.api.Assertions.fail(Assertions.java:134)

--- a/junit5/src/testIntegration/java/nz/lae/stacksrc/test/integration/MavenJUnit5IT.java
+++ b/junit5/src/testIntegration/java/nz/lae/stacksrc/test/integration/MavenJUnit5IT.java
@@ -23,7 +23,6 @@ class MavenJUnit5IT {
 
     var expectedStackTrace =
         """
-nz.lae.stacksrc.DecoratedAssertionError:
 org.opentest4j.AssertionFailedError: example failure
 	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38)
 	at org.junit.jupiter.api.Assertions.fail(Assertions.java:134)


### PR DESCRIPTION
So the output is less noisy.